### PR TITLE
Be more flexible with app ID field

### DIFF
--- a/Debian/Debhelper/Dh_Lib.pm
+++ b/Debian/Debhelper/Dh_Lib.pm
@@ -834,7 +834,7 @@ sub getpackages {
 		if (/^(?:X[BC]*-)?Package-Type:\s*(.*)/) {
 			$package_type=$1;
 		}
-		if (/^(?:XCBS-)?EOS-AppId:\s*(.*)/) {
+		if (/^(?:X[CBS]*-)?Eos-Appid:\s*(.*)/i) {
 			$eos_app_id=$1;
 		}
 		


### PR DESCRIPTION
The checking of app ID was too restrictive.
1. It required the field to be marked for Control (C), Binary (B) and
   Source (S) packages in that specific order. Neither should be
   required as the order is certainly unnecessary, and it's up to the
   package which output files to apply the field to. Only the binary
   package (B) is required for Endless bundles.
2. The case sensitivity of the match is inconsistent with Dpkg. Dpkg
   will lower case the field name then convert it to a titlecase with -
   separators. The result is that the output control field is
   Eos-Appid. Use a case insensitive match to follow that behavior.

[endlessm/eos-shell#5272]
