### PR TITLE
dh: remove dh_bugfiles from the default chain

### DIFF
--- a/dh
+++ b/dh
@@ -383,7 +383,6 @@ my @i = qw{
 	dh_installudev
 	dh_installwm
 	dh_installgsettings
-	dh_bugfiles
 	dh_ucf
 	dh_lintian
 	dh_gconf


### PR DESCRIPTION
We don't want the bug scripts to end up installed on our system.

[endlessm/eos-shell#5685]
