### PR TITLE
Revert 80c955221e83327efb984845f59648678c729978

### DIFF
--- a/dh
+++ b/dh
@@ -822,16 +822,14 @@ sub run_override {
 	my $has_explicit_target = rules_explicit_target($override);
 
 	if (defined $override_type) {
-		if ($has_explicit_target) {
-			foreach my $package (@{$packages}) {
-				my $isall=package_arch($package) eq 'all';
-				if (($override_type eq 'indep' && $isall) ||
-					($override_type eq 'arch' && !$isall)) {
-					push @todo, $package;
-				} else {
-					push @rest, $package;
-					push @options, "-N$package";
-				}
+		foreach my $package (@{$packages}) {
+			my $isall=package_arch($package) eq 'all';
+			if (($override_type eq 'indep' && $isall) ||
+				($override_type eq 'arch' && !$isall)) {
+				push @todo, $package;
+			} else {
+				push @rest, $package;
+				push @options, "-N$package";
 			}
 		}
 	}


### PR DESCRIPTION
It made dh skip "-arch" and "-indep" targets.

[dsd: backported from upstream.]
https://phabricator.endlessm.com/T19744

Signed-off-by: Niels Thykier <niels@thykier.net>