### PR TITLE
dh_installdeb: Use install_dir instead of fork+exec of install

### DIFF
--- a/dh_installdeb
+++ b/dh_installdeb
@@ -104,7 +104,7 @@ foreach my $package (@{$dh{DOPACKAGES}}) {
 	my $prefix=substr get_buildprefix($package), 1;
 	if ($prefix ne "usr" && -d "$tmp/usr") {
 		# Create the prefix if necessary
-		doit("install", "-d", "-o", 0, "-g", 0, "$tmp/$prefix");
+		install_dir("$tmp/$prefix");
 
 		# Move files from /usr to prefix and delete /usr
 		my $cmd="tar -C $tmp/usr -cf- . | tar -C $tmp/$prefix -xpf-";


### PR DESCRIPTION
install_dir is faster in recent versions of debhelper (avoiding a
fork+exec) plus it will eventually support "Rules-Requires-Root"
automatically, when a newer version of debhelper is merged.

Signed-off-by: Niels Thykier <niels@thykier.net>